### PR TITLE
fixed mktemp arg

### DIFF
--- a/.devcontainer/template-update.sh
+++ b/.devcontainer/template-update.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-TEMPDIR=$(mktemp --directory)
+TEMPDIR=$(mktemp -d)
 
 cleanup() {
   echo "Removing $TEMPDIR"


### PR DESCRIPTION
`--directory` does not work on OSX systems, `-d` does.